### PR TITLE
fix: add missing repository dependencies with provided scope

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -56,6 +56,16 @@
       <artifactId>nexus-repository-maven</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-repository-npm</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.nexus.plugins</groupId>
+      <artifactId>nexus-repository-pypi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This PR adds missing dependencies for NPM and PyPI repositories.
The scope is `provided`, as this functionality is provided by Nexus itself.