### PR TITLE
fix: skip security scan when attributes exist

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -66,6 +66,16 @@
       <artifactId>nexus-repository-pypi</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/plugin/src/main/java/io/snyk/plugins/nexus/model/ScanResult.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/model/ScanResult.java
@@ -1,0 +1,10 @@
+package io.snyk.plugins.nexus.model;
+
+public final class ScanResult {
+  public long highVulnerabilityIssueCount = 0;
+  public long mediumVulnerabilityIssueCount = 0;
+  public long lowVulnerabilityIssueCount = 0;
+  public long highLicenseIssueCount = 0;
+  public long mediumLicenseIssueCount = 0;
+  public long lowLicenseIssueCount = 0;
+}

--- a/plugin/src/main/java/io/snyk/plugins/nexus/util/Formatter.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/util/Formatter.java
@@ -1,0 +1,71 @@
+package io.snyk.plugins.nexus.util;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+import io.snyk.plugins.nexus.model.ScanResult;
+import io.snyk.sdk.model.Issue;
+import io.snyk.sdk.model.Severity;
+
+import static io.snyk.sdk.util.Predicates.distinctByKey;
+
+public final class Formatter {
+  private Formatter() {
+  }
+
+  public static long getIssuesCountBySeverity(@Nonnull List<? extends Issue> issues, @Nonnull Severity severity) {
+    return issues.stream()
+                 .filter(issue -> issue.severity == severity)
+                 .filter(distinctByKey(issue -> issue.id))
+                 .count();
+  }
+
+  public static String getVulnerabilityIssuesAsFormattedString(@Nonnull ScanResult scanResult) {
+    return String.format("%d high, %d medium, %d low", scanResult.highVulnerabilityIssueCount, scanResult.mediumVulnerabilityIssueCount, scanResult.lowVulnerabilityIssueCount);
+  }
+
+  public static String getLicenseIssuesAsFormattedString(@Nonnull ScanResult scanResult) {
+    return String.format("%d high, %d medium, %d low", scanResult.highLicenseIssueCount, scanResult.mediumLicenseIssueCount, scanResult.lowLicenseIssueCount);
+  }
+
+  public static void enrichScanResultWithVulnerabilityIssues(@Nonnull ScanResult scanResult, String formattedIssues) {
+    if (formattedIssues == null || formattedIssues.isEmpty()) {
+      scanResult.lowVulnerabilityIssueCount = 0;
+      scanResult.mediumVulnerabilityIssueCount = 0;
+      scanResult.highVulnerabilityIssueCount = 0;
+      return;
+    }
+
+    String[] parts = formattedIssues.split(", ");
+
+    String high = parts[0].replace(" high", "");
+    scanResult.highVulnerabilityIssueCount = Long.parseLong(high);
+
+    String medium = parts[1].replace(" medium", "");
+    scanResult.mediumVulnerabilityIssueCount = Long.parseLong(medium);
+
+    String low = parts[2].replace(" low", "");
+    scanResult.lowVulnerabilityIssueCount = Long.parseLong(low);
+  }
+
+  public static void enrichScanResultWithLicenseIssues(@Nonnull ScanResult scanResult, String formattedIssues) {
+    if (formattedIssues == null || formattedIssues.isEmpty()) {
+      scanResult.lowLicenseIssueCount = 0;
+      scanResult.mediumLicenseIssueCount = 0;
+      scanResult.highLicenseIssueCount = 0;
+      return;
+    }
+
+    String[] parts = formattedIssues.split(", ");
+
+    String high = parts[0].replace(" high", "");
+    scanResult.highLicenseIssueCount = Long.parseLong(high);
+
+    String medium = parts[1].replace(" medium", "");
+    scanResult.mediumLicenseIssueCount = Long.parseLong(medium);
+
+    String low = parts[2].replace(" low", "");
+    scanResult.lowLicenseIssueCount = Long.parseLong(low);
+  }
+}

--- a/plugin/src/test/java/io/snyk/plugins/nexus/util/FormatterTest.java
+++ b/plugin/src/test/java/io/snyk/plugins/nexus/util/FormatterTest.java
@@ -1,0 +1,110 @@
+package io.snyk.plugins.nexus.util;
+
+import io.snyk.plugins.nexus.model.ScanResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FormatterTest {
+
+  @Test
+  void enrichScanResultWithVulnerabilityIssues_null() {
+    // given
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithVulnerabilityIssues(scanResult, null);
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(0, scanResult.highVulnerabilityIssueCount);
+        Assertions.assertEquals(0, scanResult.mediumVulnerabilityIssueCount);
+        Assertions.assertEquals(0, scanResult.lowVulnerabilityIssueCount);
+      });
+  }
+
+  @Test
+  void enrichScanResultWithVulnerabilityIssues_empty() {
+    // given
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithVulnerabilityIssues(scanResult, "");
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(0, scanResult.highVulnerabilityIssueCount);
+        Assertions.assertEquals(0, scanResult.mediumVulnerabilityIssueCount);
+        Assertions.assertEquals(0, scanResult.lowVulnerabilityIssueCount);
+      });
+  }
+
+  @Test
+  void enrichScanResultWithVulnerabilityIssues() {
+    // given
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithVulnerabilityIssues(scanResult, "3 high, 14 medium, 2 low");
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(3, scanResult.highVulnerabilityIssueCount);
+        Assertions.assertEquals(14, scanResult.mediumVulnerabilityIssueCount);
+        Assertions.assertEquals(2, scanResult.lowVulnerabilityIssueCount);
+      });
+  }
+
+  @Test
+  void enrichScanResultWithLicenseIssues_null() {
+    // given
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithLicenseIssues(scanResult, null);
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(0, scanResult.highLicenseIssueCount);
+        Assertions.assertEquals(0, scanResult.mediumLicenseIssueCount);
+        Assertions.assertEquals(0, scanResult.lowLicenseIssueCount);
+      });
+  }
+
+  @Test
+  void enrichScanResultWithLicenseIssues_empty() {
+    // given
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithLicenseIssues(scanResult, "");
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(0, scanResult.highLicenseIssueCount);
+        Assertions.assertEquals(0, scanResult.mediumLicenseIssueCount);
+        Assertions.assertEquals(0, scanResult.lowLicenseIssueCount);
+      });
+  }
+   @Test
+  void enrichScanResultWithLicenseIssues() {
+    // given
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithLicenseIssues(scanResult, "10 high, 0 medium, 25 low");
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(10, scanResult.highLicenseIssueCount);
+        Assertions.assertEquals(0, scanResult.mediumLicenseIssueCount);
+        Assertions.assertEquals(25, scanResult.lowLicenseIssueCount);
+      });
+  }
+
+}


### PR DESCRIPTION
This PR adds functionality to skip unnecessary API calls when attributes for artifacts already exist.