### PR TITLE
test: wait 10 seconds before timing out

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -1,7 +1,9 @@
   name: Smoke Tests
   on:
     push:
-      branches: [test/smoke-tests]
+      branches:
+        - master
+    pull_request:
 
   jobs:
     smoke_tests:
@@ -50,7 +52,7 @@
 
         - name: Wait for Nexus start
           run: npx wait-on --timeout 120000 --interval 2000 http://localhost:8081/
-          
+
         - name: Wait for API status endpoint
           run: npx wait-on --timeout 120000 --interval 2000 http://localhost:8081/service/rest/v1/status/writable
 
@@ -80,7 +82,7 @@
         - uses: actions/upload-artifact@v2
           if: always()
           with:
-            name: screenshots 
+            name: screenshots
             path: /home/runner/work/nexus-snyk-security-plugin/nexus-snyk-security-plugin/test/smoke/cypress/screenshots/cypress-test.spec.js/
             retention-days: 1
 

--- a/test/smoke/cypress.json
+++ b/test/smoke/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "defaultCommandTimeout": 10000
+}


### PR DESCRIPTION
In order to reduce cypress tests being flaky, wait longer before timing out