### PR TITLE
Ignore existing annotations with `critical` license severities

### DIFF
--- a/plugin/src/main/java/io/snyk/plugins/nexus/util/Formatter.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/util/Formatter.java
@@ -1,12 +1,12 @@
 package io.snyk.plugins.nexus.util;
 
-import javax.annotation.Nonnull;
-
-import java.util.List;
-
 import io.snyk.plugins.nexus.model.ScanResult;
 import io.snyk.sdk.model.Issue;
 import io.snyk.sdk.model.Severity;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,17 +14,17 @@ import static io.snyk.sdk.util.Predicates.distinctByKey;
 
 public final class Formatter {
 
-  private static final Pattern LICENSE_ISSUES_WITH_CRITICAL_REGEX = Pattern.compile("(\\d+) critical, (\\d+) high, (\\d+) medium, (\\d+) low");
-  private static final Pattern LICENSE_ISSUES_WITHOUT_CRITICAL_REGEX = Pattern.compile("(\\d+) high, (\\d+) medium, (\\d+) low");
+  private static final Pattern ISSUES_WITH_CRITICAL_REGEX = Pattern.compile("(\\d+) critical, (\\d+) high, (\\d+) medium, (\\d+) low");
+  private static final Pattern ISSUES_WITHOUT_CRITICAL_REGEX = Pattern.compile("(\\d+) high, (\\d+) medium, (\\d+) low");
 
   private Formatter() {
   }
 
   public static long getIssuesCountBySeverity(@Nonnull List<? extends Issue> issues, @Nonnull Severity severity) {
     return issues.stream()
-                 .filter(issue -> issue.severity == severity)
-                 .filter(distinctByKey(issue -> issue.id))
-                 .count();
+      .filter(issue -> issue.severity == severity)
+      .filter(distinctByKey(issue -> issue.id))
+      .count();
   }
 
   public static String getVulnerabilityIssuesAsFormattedString(@Nonnull ScanResult scanResult) {
@@ -44,24 +44,12 @@ public final class Formatter {
       return;
     }
 
-    String[] parts = formattedIssues.split(", ");
-
-    int i = 0;
-    if (parts.length == 4) {
-      String critical = parts[i].replace(" critical", "");
-      scanResult.criticalVulnerabilityIssueCount = Long.parseLong(critical);
-      i++;
-    }
-    String high = parts[i].replace(" high", "");
-    scanResult.highVulnerabilityIssueCount = Long.parseLong(high);
-    i++;
-
-    String medium = parts[i].replace(" medium", "");
-    scanResult.mediumVulnerabilityIssueCount = Long.parseLong(medium);
-    i++;
-
-    String low = parts[i].replace(" low", "");
-    scanResult.lowVulnerabilityIssueCount = Long.parseLong(low);
+    IssueCounts issueCounts = getIssueCountsFromFormattedString(formattedIssues)
+      .orElseThrow(() -> new RuntimeException(String.format("Invalid format for vulnerability issues: %s", formattedIssues)));
+    scanResult.criticalVulnerabilityIssueCount = issueCounts.critical.orElse(Long.valueOf(0));
+    scanResult.highVulnerabilityIssueCount = issueCounts.high;
+    scanResult.mediumVulnerabilityIssueCount = issueCounts.medium;
+    scanResult.lowVulnerabilityIssueCount = issueCounts.low;
   }
 
   public static void enrichScanResultWithLicenseIssues(@Nonnull ScanResult scanResult, String formattedIssues) {
@@ -72,32 +60,54 @@ public final class Formatter {
       return;
     }
 
-    Matcher licenseIssuesWithCriticalMatch = LICENSE_ISSUES_WITH_CRITICAL_REGEX.matcher(formattedIssues);
-    if (licenseIssuesWithCriticalMatch.find()) {
-      String high = licenseIssuesWithCriticalMatch.group(2); // group(1) is critical which we don't use for licenses
-      String medium = licenseIssuesWithCriticalMatch.group(3);
-      String low = licenseIssuesWithCriticalMatch.group(4);
+    IssueCounts issueCounts = getIssueCountsFromFormattedString(formattedIssues)
+      .orElseThrow(() -> new RuntimeException(String.format("Invalid format for license issues: %s", formattedIssues)));
+    // regardless of if critical is present or not, we ignore it
+    scanResult.highLicenseIssueCount = issueCounts.high;
+    scanResult.mediumLicenseIssueCount = issueCounts.medium;
+    scanResult.lowLicenseIssueCount = issueCounts.low;
+  }
 
-      scanResult.highLicenseIssueCount = Long.parseLong(high);
-      scanResult.mediumLicenseIssueCount = Long.parseLong(medium);
-      scanResult.lowLicenseIssueCount = Long.parseLong(low);
-
-      return;
+  public static Optional<IssueCounts> getIssueCountsFromFormattedString(String formattedIssues) {
+    Matcher issuesWithCriticalMatch = ISSUES_WITH_CRITICAL_REGEX.matcher(formattedIssues);
+    if (issuesWithCriticalMatch.matches()) {
+      return Optional.of(new IssueCounts(
+        issuesWithCriticalMatch.group(1),
+        issuesWithCriticalMatch.group(2),
+        issuesWithCriticalMatch.group(3),
+        issuesWithCriticalMatch.group(4)
+      ));
     }
 
-    Matcher licenseIssuesWithoutCriticalMatch = LICENSE_ISSUES_WITHOUT_CRITICAL_REGEX.matcher(formattedIssues);
-    if (licenseIssuesWithoutCriticalMatch.matches()) {
-      String high = licenseIssuesWithoutCriticalMatch.group(1);
-      String medium = licenseIssuesWithoutCriticalMatch.group(2);
-      String low = licenseIssuesWithoutCriticalMatch.group(3);
-
-      scanResult.highLicenseIssueCount = Long.parseLong(high);
-      scanResult.mediumLicenseIssueCount = Long.parseLong(medium);
-      scanResult.lowLicenseIssueCount = Long.parseLong(low);
-
-      return;
+    Matcher issuesWithoutCriticalMatch = ISSUES_WITHOUT_CRITICAL_REGEX.matcher(formattedIssues);
+    if (issuesWithoutCriticalMatch.matches()) {
+      return Optional.of(new IssueCounts(
+        issuesWithoutCriticalMatch.group(1),
+        issuesWithoutCriticalMatch.group(2),
+        issuesWithoutCriticalMatch.group(3)
+      ));
     }
 
-    throw new RuntimeException(String.format("Invalid format for license issues: %s", formattedIssues));
+    return Optional.empty();
+  }
+}
+
+class IssueCounts {
+  Optional<Long> critical = Optional.empty();
+  long high = 0;
+  long medium = 0;
+  long low = 0;
+
+  IssueCounts(String critical, String high, String medium, String low) {
+    this.critical = Optional.of(Long.parseLong(critical));
+    this.high = Long.parseLong(high);
+    this.medium = Long.parseLong(medium);
+    this.low = Long.parseLong(low);
+  }
+
+  IssueCounts(String high, String medium, String low) {
+    this.high = Long.parseLong(high);
+    this.medium = Long.parseLong(medium);
+    this.low = Long.parseLong(low);
   }
 }

--- a/plugin/src/test/java/io/snyk/plugins/nexus/util/FormatterTest.java
+++ b/plugin/src/test/java/io/snyk/plugins/nexus/util/FormatterTest.java
@@ -81,6 +81,20 @@ class FormatterTest {
   }
 
   @Test
+  void enrichScanResultWithVulnerabilityIssuesThrowsIfInvalidFormat() {
+    ScanResult scanResult = new ScanResult();
+    RuntimeException e = assertThrows(RuntimeException.class, () -> Formatter.enrichScanResultWithVulnerabilityIssues(scanResult, "10 super, 15 elite, 20 fantastic"));
+    assertEquals(e.getMessage(), "Invalid format for vulnerability issues: 10 super, 15 elite, 20 fantastic");
+  }
+
+  @Test
+  void enrichScanResultWithVulnerabilityIssuesThrowsIfInvalidValues() {
+    ScanResult scanResult = new ScanResult();
+    RuntimeException e = assertThrows(RuntimeException.class, () -> Formatter.enrichScanResultWithVulnerabilityIssues(scanResult, "a critical, b high, c medium, d low"));
+    assertEquals(e.getMessage(), "Invalid format for vulnerability issues: a critical, b high, c medium, d low");
+  }
+
+  @Test
   void enrichScanResultWithLicenseIssues_null() {
     // given
     ScanResult scanResult = new ScanResult();
@@ -151,6 +165,13 @@ class FormatterTest {
     ScanResult scanResult = new ScanResult();
     RuntimeException e = assertThrows(RuntimeException.class, () -> Formatter.enrichScanResultWithLicenseIssues(scanResult, "10 super, 15 elite, 20 fantastic"));
     assertEquals(e.getMessage(), "Invalid format for license issues: 10 super, 15 elite, 20 fantastic");
+  }
+
+  @Test
+  void enrichScanResultWithLicenseIssuesThrowsIfInvalidValues() {
+    ScanResult scanResult = new ScanResult();
+    RuntimeException e = assertThrows(RuntimeException.class, () -> Formatter.enrichScanResultWithLicenseIssues(scanResult, "x critical, y high, 0 medium, z low"));
+    assertEquals(e.getMessage(), "Invalid format for license issues: x critical, y high, 0 medium, z low");
   }
 
 }

--- a/plugin/src/test/java/io/snyk/plugins/nexus/util/FormatterTest.java
+++ b/plugin/src/test/java/io/snyk/plugins/nexus/util/FormatterTest.java
@@ -3,6 +3,8 @@ package io.snyk.plugins.nexus.util;
 import io.snyk.plugins.nexus.model.ScanResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FormatterTest {
 
@@ -126,6 +128,29 @@ class FormatterTest {
         Assertions.assertEquals(0, scanResult.mediumLicenseIssueCount);
         Assertions.assertEquals(25, scanResult.lowLicenseIssueCount);
       });
+  }
+
+  @Test
+  void enrichScanResultWithLicenseIssuesWhenFormattedIssuesContainsCritical() {
+    ScanResult scanResult = new ScanResult();
+
+    // when
+    Formatter.enrichScanResultWithLicenseIssues(scanResult, "6 critical, 10 high, 0 medium, 25 low");
+
+    // then
+    Assertions.assertAll(
+      () -> {
+        Assertions.assertEquals(10, scanResult.highLicenseIssueCount);
+        Assertions.assertEquals(0, scanResult.mediumLicenseIssueCount);
+        Assertions.assertEquals(25, scanResult.lowLicenseIssueCount);
+      });
+  }
+
+  @Test
+  void enrichScanResultWithLicenseIssuesThrowsIfInvalidFormat() {
+    ScanResult scanResult = new ScanResult();
+    RuntimeException e = assertThrows(RuntimeException.class, () -> Formatter.enrichScanResultWithLicenseIssues(scanResult, "10 super, 15 elite, 20 fantastic"));
+    assertEquals(e.getMessage(), "Invalid format for license issues: 10 super, 15 elite, 20 fantastic");
   }
 
 }


### PR DESCRIPTION
It is possible that, by previous oversight, some license issues in Nexus have annotations including `critical` even though we don't do `critical` for licenses. This was introduced a few months ago with the big critical severities thing.

We recently partially fixed this in v0.3.1 with https://github.com/snyk/nexus-snyk-security-plugin/pull/16, however that fix didn't include the scenario where annotations were already set in Nexus from a previous version. This PR addresses this.
 
I then took some ideas from my fix and used it in some of the other related code in `plugin/src/main/java/io/snyk/plugins/nexus/util/Formatter.java` and did some refactoring to cleanup in a separate commit the overall situation.