### PR TITLE
feat: add ability for Snyk sdk to use an explicit proxy

### DIFF
--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapability.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapability.java
@@ -6,10 +6,12 @@ import java.util.Map;
 
 import org.sonatype.nexus.capability.CapabilitySupport;
 
+
 import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_TOKEN;
 
 @Named(SnykSecurityCapabilityDescriptor.CAPABILITY_ID)
 public class SnykSecurityCapability extends CapabilitySupport<SnykSecurityCapabilityConfiguration> {
+
 
   @Inject
   public SnykSecurityCapability() {

--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapability.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapability.java
@@ -10,7 +10,7 @@ import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_TOK
 
 @Named(SnykSecurityCapabilityDescriptor.CAPABILITY_ID)
 public class SnykSecurityCapability extends CapabilitySupport<SnykSecurityCapabilityConfiguration> {
-  
+
   @Inject
   public SnykSecurityCapability() {
   }

--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapability.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapability.java
@@ -6,13 +6,11 @@ import java.util.Map;
 
 import org.sonatype.nexus.capability.CapabilitySupport;
 
-
 import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_TOKEN;
 
 @Named(SnykSecurityCapabilityDescriptor.CAPABILITY_ID)
 public class SnykSecurityCapability extends CapabilitySupport<SnykSecurityCapabilityConfiguration> {
-
-
+  
   @Inject
   public SnykSecurityCapability() {
   }

--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityConfiguration.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityConfiguration.java
@@ -4,11 +4,7 @@ import java.util.Map;
 
 import org.sonatype.nexus.capability.CapabilityConfigurationSupport;
 
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_TOKEN;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_URL;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.LICENSE_THRESHOLD;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.ORGANIZATION_ID;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.VULNERABILITY_THRESHOLD;
+import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.*;
 
 public class SnykSecurityCapabilityConfiguration extends CapabilityConfigurationSupport {
   private String apiUrl;
@@ -16,6 +12,10 @@ public class SnykSecurityCapabilityConfiguration extends CapabilityConfiguration
   private String organizationId;
   private String vulnerabilityThreshold;
   private String licenseThreshold;
+  private String proxyHost;
+  private String proxyPort;
+  private String proxyUser;
+  private String proxyPassword;
 
   SnykSecurityCapabilityConfiguration(Map<String, String> properties) {
     apiUrl = properties.getOrDefault(API_URL.propertyKey(), API_URL.defaultValue());
@@ -23,6 +23,10 @@ public class SnykSecurityCapabilityConfiguration extends CapabilityConfiguration
     organizationId = properties.get(ORGANIZATION_ID.propertyKey());
     vulnerabilityThreshold = properties.getOrDefault(VULNERABILITY_THRESHOLD.propertyKey(), VULNERABILITY_THRESHOLD.defaultValue());
     licenseThreshold = properties.getOrDefault(LICENSE_THRESHOLD.propertyKey(), LICENSE_THRESHOLD.defaultValue());
+    proxyHost = properties.getOrDefault(PROXY_HOST.propertyKey(), PROXY_HOST.defaultValue());
+    proxyPort = properties.getOrDefault(PROXY_PORT.propertyKey(), PROXY_PORT.defaultValue());
+    proxyUser = properties.getOrDefault(PROXY_USER.propertyKey(), PROXY_USER.defaultValue());
+    proxyPassword = properties.getOrDefault(PROXY_PASSWORD.propertyKey(), PROXY_PASSWORD.defaultValue());
 
   }
 
@@ -44,5 +48,18 @@ public class SnykSecurityCapabilityConfiguration extends CapabilityConfiguration
 
   public String getLicenseThreshold() {
     return licenseThreshold;
+  }
+
+  public String getProxyHost() {
+    return proxyHost;
+  }
+  public String getProxyPort() {
+    return proxyPort;
+  }
+  public String getProxyUser() {
+    return proxyUser;
+  }
+  public String getProxyPassword() {
+    return proxyPassword;
   }
 }

--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityDescriptor.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityDescriptor.java
@@ -15,13 +15,9 @@ import org.sonatype.nexus.capability.Taggable;
 import org.sonatype.nexus.formfields.CheckboxFormField;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
+import org.sonatype.nexus.formfields.PasswordFormField;
 
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_TOKEN;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_TRUST_ALL_CERTIFICATES;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.API_URL;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.LICENSE_THRESHOLD;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.ORGANIZATION_ID;
-import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.VULNERABILITY_THRESHOLD;
+import static io.snyk.plugins.nexus.capability.SnykSecurityCapabilityKey.*;
 
 @Singleton
 @Named(SnykSecurityCapabilityDescriptor.CAPABILITY_ID)
@@ -36,6 +32,10 @@ public class SnykSecurityCapabilityDescriptor extends CapabilityDescriptorSuppor
   private final StringTextFormField fieldOrganizationId;
   private final StringTextFormField fieldVulnerabilityThreshold;
   private final StringTextFormField fieldLicenseThreshold;
+  private final StringTextFormField fieldProxyHost;
+  private final StringTextFormField fieldProxyPort;
+  private final StringTextFormField fieldProxyUser;
+  private final PasswordFormField fieldProxyPassword;
 
   public SnykSecurityCapabilityDescriptor() {
     fieldApiUrl = new StringTextFormField(API_URL.propertyKey(), "Snyk API URL", "", FormField.MANDATORY).withInitialValue(API_URL.defaultValue());
@@ -44,6 +44,10 @@ public class SnykSecurityCapabilityDescriptor extends CapabilityDescriptorSuppor
     fieldOrganizationId = new StringTextFormField(ORGANIZATION_ID.propertyKey(), "Snyk Organization ID", "", FormField.MANDATORY).withInitialValue(ORGANIZATION_ID.defaultValue());
     fieldVulnerabilityThreshold = new StringTextFormField(VULNERABILITY_THRESHOLD.propertyKey(), "Vulnerability Threshold", "", FormField.MANDATORY).withInitialValue(VULNERABILITY_THRESHOLD.defaultValue());
     fieldLicenseThreshold = new StringTextFormField(LICENSE_THRESHOLD.propertyKey(), "License Threshold", "", FormField.MANDATORY).withInitialValue(LICENSE_THRESHOLD.defaultValue());
+    fieldProxyHost = new StringTextFormField(PROXY_HOST.propertyKey(), "Proxy host (optional)", "", FormField.OPTIONAL).withInitialValue(PROXY_HOST.defaultValue());
+    fieldProxyPort = new StringTextFormField(PROXY_PORT.propertyKey(), "Proxy port (optional)", "", FormField.OPTIONAL).withInitialValue(PROXY_PORT.defaultValue());
+    fieldProxyUser = new StringTextFormField(PROXY_USER.propertyKey(), "Proxy username (optional)", "", FormField.OPTIONAL).withInitialValue(PROXY_USER.defaultValue());
+    fieldProxyPassword = new PasswordFormField(PROXY_PASSWORD.propertyKey(), "Proxy password (optional)", "", FormField.OPTIONAL).withInitialValue(PROXY_PASSWORD.defaultValue());
   }
 
   @Override
@@ -63,7 +67,7 @@ public class SnykSecurityCapabilityDescriptor extends CapabilityDescriptorSuppor
 
   @Override
   public List<FormField> formFields() {
-    return Arrays.asList(fieldApiUrl, fieldApiToken, fieldUseCustomSSLCertificate, fieldOrganizationId, fieldVulnerabilityThreshold, fieldLicenseThreshold);
+    return Arrays.asList(fieldApiUrl, fieldApiToken, fieldUseCustomSSLCertificate, fieldOrganizationId, fieldVulnerabilityThreshold, fieldLicenseThreshold, fieldProxyHost, fieldProxyPort, fieldProxyUser, fieldProxyPassword);
   }
 
   @Override

--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityKey.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityKey.java
@@ -6,7 +6,11 @@ public enum SnykSecurityCapabilityKey {
   API_TRUST_ALL_CERTIFICATES("snyk.api.trust.all.certificates", "false"),
   ORGANIZATION_ID("snyk.organization.id", ""),
   VULNERABILITY_THRESHOLD("snyk.scanner.vulnerability.threshold", "low"),
-  LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low");
+  LICENSE_THRESHOLD("snyk.scanner.license.threshold", "low"),
+  PROXY_HOST("snyk.proxy.host", ""),
+  PROXY_PORT("snyk.proxy.port", ""),
+  PROXY_USER("snyk.proxy.user", ""),
+  PROXY_PASSWORD("snyk.proxy.password", "");
 
   private final String propertyKey;
   private final String defaultValue;

--- a/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityLocator.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/capability/SnykSecurityCapabilityLocator.java
@@ -9,6 +9,9 @@ import org.sonatype.nexus.capability.Capability;
 import org.sonatype.nexus.capability.CapabilityReference;
 import org.sonatype.nexus.capability.CapabilityRegistry;
 
+import java.util.Optional;
+import java.util.Set;
+
 @Named
 public class SnykSecurityCapabilityLocator {
   private static final Logger LOG = LoggerFactory.getLogger(SnykSecurityCapabilityLocator.class);

--- a/plugin/src/main/java/io/snyk/plugins/nexus/scanner/ConfigurationHelper.java
+++ b/plugin/src/main/java/io/snyk/plugins/nexus/scanner/ConfigurationHelper.java
@@ -10,8 +10,14 @@ import io.snyk.plugins.nexus.capability.SnykSecurityCapabilityConfiguration;
 import io.snyk.plugins.nexus.capability.SnykSecurityCapabilityLocator;
 import io.snyk.sdk.Snyk;
 import io.snyk.sdk.api.v1.SnykClient;
+import io.snyk.sdk.config.SnykProxyConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonatype.nexus.httpclient.config.ProxyConfiguration;
+import org.sonatype.nexus.httpclient.config.ProxyServerConfiguration;
+import org.sonatype.nexus.httpclient.config.UsernameAuthenticationConfiguration;
+
+import java.util.Optional;
 
 @Named
 @Singleton
@@ -30,6 +36,14 @@ public class ConfigurationHelper {
       return null;
     } else {
       try {
+        String proxyHost = locator.getSnykSecurityCapabilityConfiguration().getProxyHost();
+        String proxyPort = locator.getSnykSecurityCapabilityConfiguration().getProxyPort();
+        String proxyUser = locator.getSnykSecurityCapabilityConfiguration().getProxyUser();
+        String proxyPassword = locator.getSnykSecurityCapabilityConfiguration().getProxyPassword();
+        if(!proxyHost.isEmpty() && !proxyPort.isEmpty()) {
+            SnykProxyConfig snykProxyConfig = new SnykProxyConfig(proxyHost, Integer.parseInt(proxyPort), proxyUser, proxyPassword);
+            return Snyk.newBuilder(new Snyk.Config(locator.getSnykSecurityCapabilityConfiguration().getApiToken(), snykProxyConfig)).buildSync();
+        }
         return Snyk.newBuilder(new Snyk.Config(locator.getSnykSecurityCapabilityConfiguration().getApiToken())).buildSync();
       } catch (Exception ex) {
         LOG.error("SnykClient could not be created", ex);

--- a/snyk-sdk/src/main/java/io/snyk/sdk/Snyk.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/Snyk.java
@@ -41,7 +41,6 @@ public class Snyk {
                                                              .readTimeout(DEFAULT_READ_TIMEOUT, MILLISECONDS)
                                                              .writeTimeout(DEFAULT_WRITE_TIMEOUT, MILLISECONDS);
 
-    // Do some proxy configuration - by default follows options set in JAVA_OPTS
     configureProxy(builder, config);
 
     if (config.trustAllCertificates) {

--- a/snyk-sdk/src/main/java/io/snyk/sdk/config/SnykProxyConfig.java
+++ b/snyk-sdk/src/main/java/io/snyk/sdk/config/SnykProxyConfig.java
@@ -1,0 +1,31 @@
+package io.snyk.sdk.config;
+
+public class SnykProxyConfig {
+  private final String proxyHost;
+  private final int proxyPort;
+  private final String proxyUser;
+  private final String proxyPassword;
+
+  public SnykProxyConfig(String proxyHost, int proxyPort, String proxyUser, String proxyPassword) {
+    this.proxyHost = proxyHost;
+    this.proxyPort = proxyPort;
+    this.proxyUser = proxyUser;
+    this.proxyPassword = proxyPassword;
+  }
+
+  public String getProxyHost() {
+    return proxyHost;
+  }
+
+  public int getProxyPort() {
+    return proxyPort;
+  }
+
+  public String getProxyUser() {
+    return proxyUser;
+  }
+
+  public String getProxyPassword() {
+    return proxyPassword;
+  }
+}


### PR DESCRIPTION
This change allows the Snyk SDK to use an explicit proxy. The proxy settings are set under the capability settings, this will allow users to optionally set the proxy host, proxy port, username and password.

These changes are likely to be used by enterprise customers where their Nexus environment is in an air-gapped environment and has no direct internet connectivity.

Note: I did try looking in to if the proxy settings could be retrieved from Nexus itself by Injecting the "ProxyConfiguration" instance. It seems this isn't exposed publicly, however. I believe the only other way we could do this is by making API calls, which Nexus credentials would be required for - it seems like more trouble than it's worth!